### PR TITLE
BAU: inlined saml-domain-objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
             configurations.opensaml,
             "uk.gov.ida:saml-serializers:$opensaml_version-50",
             "uk.gov.ida:saml-security:$opensaml_version-56",
-            "uk.gov.verify:saml-domain-objects:$opensaml_version-42",
             'com.google.guava:guava:18.0',
             'com.google.inject:guice:4.0',
             'joda-time:joda-time:2.9'

--- a/src/main/java/uk/gov/ida/saml/core/OpenSamlXmlObjectFactory.java
+++ b/src/main/java/uk/gov/ida/saml/core/OpenSamlXmlObjectFactory.java
@@ -1,0 +1,456 @@
+package uk.gov.ida.saml.core;
+
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.XMLObjectBuilder;
+import org.opensaml.core.xml.XMLObjectBuilderFactory;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.Audience;
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import org.opensaml.saml.saml2.core.AuthnContext;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.NameIDPolicy;
+import org.opensaml.saml.saml2.core.RequestedAuthnContext;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Scoping;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.core.StatusDetail;
+import org.opensaml.saml.saml2.core.StatusMessage;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.AttributeAuthorityDescriptor;
+import org.opensaml.saml.saml2.metadata.AttributeService;
+import org.opensaml.saml.saml2.metadata.Company;
+import org.opensaml.saml.saml2.metadata.ContactPerson;
+import org.opensaml.saml.saml2.metadata.EmailAddress;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.GivenName;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.saml.saml2.metadata.Organization;
+import org.opensaml.saml.saml2.metadata.OrganizationDisplayName;
+import org.opensaml.saml.saml2.metadata.OrganizationName;
+import org.opensaml.saml.saml2.metadata.OrganizationURL;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleSignOnService;
+import org.opensaml.saml.saml2.metadata.SurName;
+import org.opensaml.saml.saml2.metadata.TelephoneNumber;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.xmlsec.signature.KeyInfo;
+import org.opensaml.xmlsec.signature.KeyName;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.X509Certificate;
+import org.opensaml.xmlsec.signature.X509Data;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+import uk.gov.ida.saml.core.extensions.Address;
+import uk.gov.ida.saml.core.extensions.Date;
+import uk.gov.ida.saml.core.extensions.Gender;
+import uk.gov.ida.saml.core.extensions.Gpg45Status;
+import uk.gov.ida.saml.core.extensions.IPAddress;
+import uk.gov.ida.saml.core.extensions.IdpFraudEventId;
+import uk.gov.ida.saml.core.extensions.InternationalPostCode;
+import uk.gov.ida.saml.core.extensions.Line;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.core.extensions.PostCode;
+import uk.gov.ida.saml.core.extensions.StatusValue;
+import uk.gov.ida.saml.core.extensions.StringBasedMdsAttributeValue;
+import uk.gov.ida.saml.core.extensions.UPRN;
+import uk.gov.ida.saml.core.extensions.Verified;
+
+import javax.validation.constraints.NotNull;
+import javax.xml.namespace.QName;
+
+public class OpenSamlXmlObjectFactory {
+
+    private XMLObjectBuilderFactory openSamlBuilderFactory;
+
+    public OpenSamlXmlObjectFactory() {
+        openSamlBuilderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+    }
+
+    public Subject createSubject() {
+        return (Subject) openSamlBuilderFactory.getBuilder(Subject.DEFAULT_ELEMENT_NAME).buildObject(Subject.DEFAULT_ELEMENT_NAME, Subject.TYPE_NAME);
+    }
+
+    public AttributeQuery createAttributeQuery() {
+        return (AttributeQuery) openSamlBuilderFactory.getBuilder(AttributeQuery.DEFAULT_ELEMENT_NAME).buildObject(AttributeQuery.DEFAULT_ELEMENT_NAME, AttributeQuery.TYPE_NAME);
+    }
+
+    public NameID createNameId(String nameId) {
+        NameID retVal = (NameID) openSamlBuilderFactory.getBuilder(NameID.DEFAULT_ELEMENT_NAME).buildObject(NameID.DEFAULT_ELEMENT_NAME);
+        retVal.setFormat(NameID.PERSISTENT);
+        retVal.setValue(nameId);
+        return retVal;
+    }
+
+    public Issuer createIssuer(String issuer) {
+        Issuer retVal = (Issuer) openSamlBuilderFactory.getBuilder(Issuer.DEFAULT_ELEMENT_NAME).buildObject(Issuer.DEFAULT_ELEMENT_NAME);
+        retVal.setFormat(Issuer.ENTITY);
+        retVal.setValue(issuer);
+        return retVal;
+    }
+
+    public Status createStatus() {
+        return (Status) openSamlBuilderFactory.getBuilder(Status.DEFAULT_ELEMENT_NAME).buildObject(Status.DEFAULT_ELEMENT_NAME, Status.TYPE_NAME);
+    }
+
+    public StatusMessage createStatusMessage() {
+        return (StatusMessage) openSamlBuilderFactory.getBuilder(StatusMessage.DEFAULT_ELEMENT_NAME).buildObject(StatusMessage.DEFAULT_ELEMENT_NAME);
+    }
+
+    public StatusCode createStatusCode() {
+        return (StatusCode) openSamlBuilderFactory.getBuilder(StatusCode.DEFAULT_ELEMENT_NAME).buildObject(StatusCode.DEFAULT_ELEMENT_NAME, StatusCode.TYPE_NAME);
+    }
+
+    public Attribute createAttribute() {
+        return (Attribute) openSamlBuilderFactory.getBuilder(Attribute.DEFAULT_ELEMENT_NAME).buildObject(Attribute.DEFAULT_ELEMENT_NAME, Attribute.TYPE_NAME);
+    }
+
+    public AttributeStatement createAttributeStatement() {
+        return (AttributeStatement) openSamlBuilderFactory.getBuilder(AttributeStatement.DEFAULT_ELEMENT_NAME).buildObject(AttributeStatement.DEFAULT_ELEMENT_NAME, AttributeStatement.TYPE_NAME);
+    }
+
+    public Response createResponse() {
+        return (Response) openSamlBuilderFactory.getBuilder(Response.DEFAULT_ELEMENT_NAME).buildObject(Response.DEFAULT_ELEMENT_NAME, Response.TYPE_NAME);
+    }
+
+    public Assertion createAssertion() {
+        return (Assertion) openSamlBuilderFactory.getBuilder(Assertion.DEFAULT_ELEMENT_NAME).buildObject(Assertion.DEFAULT_ELEMENT_NAME, Assertion.TYPE_NAME);
+    }
+
+    public SubjectConfirmation createSubjectConfirmation() {
+        return (SubjectConfirmation) openSamlBuilderFactory.getBuilder(SubjectConfirmation.DEFAULT_ELEMENT_NAME).buildObject(SubjectConfirmation.DEFAULT_ELEMENT_NAME, SubjectConfirmation.TYPE_NAME);
+    }
+
+    public SubjectConfirmationData createSubjectConfirmationData() {
+        return (SubjectConfirmationData) openSamlBuilderFactory.getBuilder(SubjectConfirmationData.DEFAULT_ELEMENT_NAME).buildObject(SubjectConfirmationData.DEFAULT_ELEMENT_NAME, SubjectConfirmationData.TYPE_NAME);
+    }
+
+    public AuthnRequest createAuthnRequest() {
+        return (AuthnRequest) openSamlBuilderFactory.getBuilder(AuthnRequest.DEFAULT_ELEMENT_NAME).buildObject(AuthnRequest.DEFAULT_ELEMENT_NAME, AuthnRequest.TYPE_NAME);
+    }
+
+    private Audience createAudience(String audienceId) {
+        Audience audience = (Audience) openSamlBuilderFactory.getBuilder(Audience.DEFAULT_ELEMENT_NAME).buildObject(Audience.DEFAULT_ELEMENT_NAME);
+        audience.setAudienceURI(audienceId);
+
+        return audience;
+    }
+
+    public AudienceRestriction createAudienceRestriction(String audienceId) {
+        Audience audience = createAudience(audienceId);
+        AudienceRestriction audienceRestriction = (AudienceRestriction) openSamlBuilderFactory.getBuilder(AudienceRestriction.DEFAULT_ELEMENT_NAME).buildObject(AudienceRestriction.DEFAULT_ELEMENT_NAME, AudienceRestriction.TYPE_NAME);
+        audienceRestriction.getAudiences().add(audience);
+
+        return audienceRestriction;
+    }
+
+    public Conditions createConditions() {
+        return (Conditions) openSamlBuilderFactory.getBuilder(Conditions.DEFAULT_ELEMENT_NAME).buildObject(Conditions.DEFAULT_ELEMENT_NAME, Conditions.TYPE_NAME);
+    }
+
+    public Scoping createScoping() {
+        return (Scoping) openSamlBuilderFactory.getBuilder(Scoping.DEFAULT_ELEMENT_NAME).buildObject(Scoping.DEFAULT_ELEMENT_NAME);
+    }
+
+    public RequestedAuthnContext createRequestedAuthnContext(AuthnContextComparisonTypeEnumeration authnContextComparisonTypeEnumeration) {
+        RequestedAuthnContext requestedAuthnContext = (RequestedAuthnContext) openSamlBuilderFactory.getBuilder(RequestedAuthnContext.DEFAULT_ELEMENT_NAME).buildObject(RequestedAuthnContext.DEFAULT_ELEMENT_NAME);
+        requestedAuthnContext.setComparison(authnContextComparisonTypeEnumeration);
+        return requestedAuthnContext;
+    }
+
+    public AuthnContext createAuthnContext() {
+        return (AuthnContext) openSamlBuilderFactory.getBuilder(AuthnContext.DEFAULT_ELEMENT_NAME).buildObject(AuthnContext.DEFAULT_ELEMENT_NAME);
+    }
+
+    public AuthnContextClassRef createAuthnContextClassReference(String authnContextUrn) {
+        AuthnContextClassRef authnContextClassRef = (AuthnContextClassRef) openSamlBuilderFactory.getBuilder(AuthnContextClassRef.DEFAULT_ELEMENT_NAME).buildObject(AuthnContextClassRef.DEFAULT_ELEMENT_NAME);
+        authnContextClassRef.setAuthnContextClassRef(authnContextUrn);
+        return authnContextClassRef;
+    }
+
+    public NameIDPolicy createNameIdPolicy() {
+        return (NameIDPolicy) openSamlBuilderFactory.getBuilder(NameIDPolicy.DEFAULT_ELEMENT_NAME).buildObject(NameIDPolicy.DEFAULT_ELEMENT_NAME, NameIDPolicy.TYPE_NAME);
+    }
+
+    public Address createAddressAttributeValue() {
+        return (Address) openSamlBuilderFactory.getBuilder(Address.TYPE_NAME).buildObject(Address.DEFAULT_ELEMENT_NAME, Address.TYPE_NAME);
+    }
+
+    public PostCode createPostCode(String postCode) {
+        PostCode postCodeObject = (PostCode) openSamlBuilderFactory.getBuilder(PostCode.DEFAULT_ELEMENT_NAME).buildObject(PostCode.DEFAULT_ELEMENT_NAME);
+        postCodeObject.setValue(postCode);
+        return postCodeObject;
+    }
+
+    public InternationalPostCode createInternationalPostCode(String internationalPostCode) {
+        InternationalPostCode internationalPostCodeObject = (InternationalPostCode) openSamlBuilderFactory.getBuilder(InternationalPostCode.DEFAULT_ELEMENT_NAME).buildObject(InternationalPostCode.DEFAULT_ELEMENT_NAME);
+        internationalPostCodeObject.setValue(internationalPostCode);
+        return internationalPostCodeObject;
+    }
+
+    public UPRN createUPRN(String uprn) {
+        UPRN uprnObject = (UPRN) openSamlBuilderFactory.getBuilder(UPRN.DEFAULT_ELEMENT_NAME).buildObject(UPRN.DEFAULT_ELEMENT_NAME);
+        uprnObject.setValue(uprn);
+        return uprnObject;
+    }
+
+    public Line createLine(String line) {
+        Line lineObject = (Line) openSamlBuilderFactory.getBuilder(Line.DEFAULT_ELEMENT_NAME).buildObject(Line.DEFAULT_ELEMENT_NAME);
+        lineObject.setValue(line);
+        return lineObject;
+    }
+
+    public PersonName createPersonNameAttributeValue(String name) {
+        PersonName personNameObject = (PersonName) openSamlBuilderFactory.getBuilder(PersonName.TYPE_NAME).buildObject(PersonName.DEFAULT_ELEMENT_NAME, PersonName.TYPE_NAME);
+        personNameObject.setValue(name);
+        personNameObject.setLanguage(IdaConstants.IDA_LANGUAGE);
+        return personNameObject;
+    }
+
+    public Gender createGenderAttributeValue(String value) {
+        Gender genderObject = (Gender) openSamlBuilderFactory.getBuilder(Gender.TYPE_NAME).buildObject(Gender.DEFAULT_ELEMENT_NAME, Gender.TYPE_NAME);
+        genderObject.setValue(value);
+        return genderObject;
+    }
+
+    public Date createDateAttributeValue(String dateTime) {
+        Date dateObject = (Date) openSamlBuilderFactory.getBuilder(Date.TYPE_NAME).buildObject(Date.DEFAULT_ELEMENT_NAME, Date.TYPE_NAME);
+        dateObject.setValue(dateTime);
+        return dateObject;
+    }
+
+    public Verified createVerifiedAttributeValue(boolean value) {
+        Verified verifiedObject = (Verified) openSamlBuilderFactory.getBuilder(Verified.TYPE_NAME).buildObject(Verified.DEFAULT_ELEMENT_NAME, Verified.TYPE_NAME);
+        verifiedObject.setValue(value);
+        return verifiedObject;
+    }
+
+    public AuthnStatement createAuthnStatement() {
+        return (AuthnStatement) openSamlBuilderFactory.getBuilder(AuthnStatement.TYPE_NAME).buildObject(AuthnStatement.DEFAULT_ELEMENT_NAME, AuthnStatement.TYPE_NAME);
+    }
+
+    public EntityDescriptor createEntityDescriptor() {
+        return (EntityDescriptor) openSamlBuilderFactory.getBuilder(EntityDescriptor.TYPE_NAME).buildObject(EntityDescriptor.DEFAULT_ELEMENT_NAME, EntityDescriptor.TYPE_NAME);
+    }
+
+    public Organization createOrganization() {
+        return (Organization) openSamlBuilderFactory.getBuilder(Organization.TYPE_NAME).buildObject(Organization.DEFAULT_ELEMENT_NAME, Organization.TYPE_NAME);
+    }
+
+    public SingleSignOnService createSingleSignOnService(String binding, String location) {
+        SingleSignOnService singleSignOnService = (SingleSignOnService) openSamlBuilderFactory.getBuilder(SingleSignOnService.DEFAULT_ELEMENT_NAME).buildObject(SingleSignOnService.DEFAULT_ELEMENT_NAME, SingleSignOnService.TYPE_NAME);
+        singleSignOnService.setBinding(binding);
+        singleSignOnService.setLocation(location);
+        return singleSignOnService;
+    }
+
+    public AssertionConsumerService createAssertionConsumerService(String binding, String location, Integer index, boolean isDefault) {
+        AssertionConsumerService assertionConsumerService = (AssertionConsumerService) openSamlBuilderFactory.getBuilder(AssertionConsumerService.DEFAULT_ELEMENT_NAME).buildObject(AssertionConsumerService.DEFAULT_ELEMENT_NAME, AssertionConsumerService.TYPE_NAME);
+        assertionConsumerService.setBinding(binding);
+        assertionConsumerService.setLocation(location);
+        assertionConsumerService.setIndex(index);
+        assertionConsumerService.setIsDefault(isDefault);
+        return assertionConsumerService;
+    }
+
+    public IDPSSODescriptor createIDPSSODescriptor() {
+        return (IDPSSODescriptor) openSamlBuilderFactory.getBuilder(IDPSSODescriptor.DEFAULT_ELEMENT_NAME).buildObject(IDPSSODescriptor.DEFAULT_ELEMENT_NAME, IDPSSODescriptor.TYPE_NAME);
+    }
+
+    public SPSSODescriptor createSPSSODescriptor() {
+        return (SPSSODescriptor) openSamlBuilderFactory.getBuilder(SPSSODescriptor.DEFAULT_ELEMENT_NAME).buildObject(SPSSODescriptor.DEFAULT_ELEMENT_NAME, SPSSODescriptor.TYPE_NAME);
+    }
+
+    public AttributeAuthorityDescriptor createAttributeAuthorityDescriptor() {
+        return (AttributeAuthorityDescriptor) openSamlBuilderFactory
+                .getBuilder(AttributeAuthorityDescriptor.DEFAULT_ELEMENT_NAME)
+                .buildObject(AttributeAuthorityDescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    public AttributeService createAttributeService() {
+        return (AttributeService) openSamlBuilderFactory
+                .getBuilder(AttributeService.DEFAULT_ELEMENT_NAME)
+                .buildObject(AttributeService.DEFAULT_ELEMENT_NAME);
+    }
+
+    public OrganizationDisplayName createOrganizationDisplayName(String name) {
+        OrganizationDisplayName organizationDisplayName = (OrganizationDisplayName) openSamlBuilderFactory.getBuilder(OrganizationDisplayName.DEFAULT_ELEMENT_NAME).buildObject(OrganizationDisplayName.DEFAULT_ELEMENT_NAME, OrganizationDisplayName.TYPE_NAME);
+        organizationDisplayName.setValue(name);
+        organizationDisplayName.setXMLLang(IdaConstants.IDA_LANGUAGE);
+        return organizationDisplayName;
+    }
+
+    public OrganizationName createOrganizationName(String name) {
+        OrganizationName organizationName = (OrganizationName) openSamlBuilderFactory.getBuilder(OrganizationName.DEFAULT_ELEMENT_NAME).buildObject(OrganizationName.DEFAULT_ELEMENT_NAME, OrganizationName.TYPE_NAME);
+        organizationName.setValue(name);
+        organizationName.setXMLLang(IdaConstants.IDA_LANGUAGE);
+        return organizationName;
+    }
+
+    public OrganizationURL createOrganizationUrl(String url) {
+        OrganizationURL organizationUrl = (OrganizationURL) openSamlBuilderFactory.getBuilder(OrganizationURL.DEFAULT_ELEMENT_NAME).buildObject(OrganizationURL.DEFAULT_ELEMENT_NAME, OrganizationURL.TYPE_NAME);
+        organizationUrl.setValue(url);
+        organizationUrl.setXMLLang(IdaConstants.IDA_LANGUAGE);
+        return organizationUrl;
+    }
+
+    public KeyDescriptor createKeyDescriptor(String use) {
+        KeyDescriptor keyDescriptor = (KeyDescriptor) openSamlBuilderFactory.getBuilder(KeyDescriptor.DEFAULT_ELEMENT_NAME).buildObject(KeyDescriptor.DEFAULT_ELEMENT_NAME, KeyDescriptor.TYPE_NAME);
+        keyDescriptor.setUse(UsageType.valueOf(use.toUpperCase()));
+        return keyDescriptor;
+    }
+
+    public X509Certificate createX509Certificate(String cert) {
+        X509Certificate x509Certificate = (X509Certificate) openSamlBuilderFactory.getBuilder(X509Certificate.DEFAULT_ELEMENT_NAME).buildObject(X509Certificate.DEFAULT_ELEMENT_NAME);
+        x509Certificate.setValue(cert);
+        return x509Certificate;
+    }
+
+    public X509Data createX509Data() {
+        return (X509Data) openSamlBuilderFactory.getBuilder(X509Data.DEFAULT_ELEMENT_NAME).buildObject(X509Data.DEFAULT_ELEMENT_NAME, X509Data.TYPE_NAME);
+    }
+
+    public KeyInfo createKeyInfo(String keyNameValue) {
+        final KeyInfo keyInfo = (KeyInfo) openSamlBuilderFactory.getBuilder(KeyInfo.DEFAULT_ELEMENT_NAME).buildObject(KeyInfo.DEFAULT_ELEMENT_NAME, KeyInfo.TYPE_NAME);
+        if (keyNameValue != null) {
+            KeyName keyName = createKeyName(keyNameValue);
+            keyInfo.getKeyNames().add(keyName);
+        }
+        return keyInfo;
+    }
+
+    public KeyInfo createKeyInfo(final String issuerId, final String certificateValue) {
+        KeyInfo keyInfo = createKeyInfo(issuerId);
+        X509Data x509Data = createX509Data();
+        final X509Certificate x509Certificate = createX509Certificate(certificateValue);
+        x509Data.getX509Certificates().add(x509Certificate);
+        keyInfo.getX509Datas().add(x509Data);
+        return keyInfo;
+    }
+
+    private KeyName createKeyName(String keyNameValue) {
+        final KeyName keyName = (KeyName) openSamlBuilderFactory.getBuilder(KeyName.DEFAULT_ELEMENT_NAME).buildObject(KeyName.DEFAULT_ELEMENT_NAME);
+        keyName.setValue(keyNameValue);
+        return keyName;
+    }
+
+    public Signature createSignature() {
+        final XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+        final XMLObjectBuilder<?> builder = builderFactory.getBuilder(Signature.DEFAULT_ELEMENT_NAME);
+        final XMLObject xmlObject = builder.buildObject(Signature.DEFAULT_ELEMENT_NAME);
+        Signature signature = (Signature) xmlObject;
+
+        signature.setSignatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA);
+        signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
+        return signature;
+    }
+
+    public Signature createSignature(@NotNull Credential signingCredential) {
+        Signature signature = createSignature();
+        signature.setSigningCredential(signingCredential);
+        return signature;
+    }
+
+    public Signature createSignature(@NotNull SignatureAlgorithm signatureAlgorithm) {
+        Signature signature = createSignature();
+        signature.setSignatureAlgorithm(signatureAlgorithm.toString());
+        return signature;
+    }
+
+    public Signature createSignature(@NotNull Credential signingCredential, @NotNull SignatureAlgorithm signatureAlgorithm) {
+        Signature signature = createSignature(signingCredential);
+        signature.setSignatureAlgorithm(signatureAlgorithm.toString());
+        return signature;
+    }
+
+    public SAMLVersion createSamlVersion(String samlVersion) {
+        return SAMLVersion.valueOf(samlVersion);
+    }
+
+    // There is a bug in OpenSaml where the type name for the element is wrong, hence the inline creation of the QName.
+    public ContactPerson createContactPerson() {
+        return (ContactPerson) openSamlBuilderFactory.getBuilder(ContactPerson.DEFAULT_ELEMENT_NAME).buildObject(ContactPerson.DEFAULT_ELEMENT_NAME, new QName(SAMLConstants.SAML20MD_NS, "ContactType", SAMLConstants.SAML20MD_PREFIX));
+    }
+
+    public EmailAddress createEmailAddress(String address) {
+        EmailAddress emailAddress = (EmailAddress) openSamlBuilderFactory.getBuilder(EmailAddress.DEFAULT_ELEMENT_NAME).buildObject(EmailAddress.DEFAULT_ELEMENT_NAME);
+        emailAddress.setAddress(address);
+        return emailAddress;
+    }
+
+    public TelephoneNumber createTelephoneNumber(String number) {
+        TelephoneNumber telephoneNumber = (TelephoneNumber) openSamlBuilderFactory.getBuilder(TelephoneNumber.DEFAULT_ELEMENT_NAME).buildObject(TelephoneNumber.DEFAULT_ELEMENT_NAME);
+        telephoneNumber.setNumber(number);
+        return telephoneNumber;
+    }
+
+    public GivenName createGivenName(String name) {
+        GivenName givenName = (GivenName) openSamlBuilderFactory.getBuilder(GivenName.DEFAULT_ELEMENT_NAME).buildObject(GivenName.DEFAULT_ELEMENT_NAME);
+        givenName.setName(name);
+        return givenName;
+    }
+
+    public SurName createSurName(String name) {
+        SurName surName = (SurName) openSamlBuilderFactory.getBuilder(SurName.DEFAULT_ELEMENT_NAME).buildObject(SurName.DEFAULT_ELEMENT_NAME);
+        surName.setName(name);
+        return surName;
+    }
+
+    public Company createCompany(String name) {
+        Company company = (Company) openSamlBuilderFactory.getBuilder(Company.DEFAULT_ELEMENT_NAME).buildObject(Company.DEFAULT_ELEMENT_NAME);
+        company.setName(name);
+        return company;
+    }
+
+    public StringBasedMdsAttributeValue createSimpleMdsAttributeValue(String value) {
+        StringBasedMdsAttributeValue stringBasedMdsAttributeValue = (StringBasedMdsAttributeValue) openSamlBuilderFactory.getBuilder(StringBasedMdsAttributeValue.TYPE_NAME).buildObject(StringBasedMdsAttributeValue.DEFAULT_ELEMENT_NAME, StringBasedMdsAttributeValue.TYPE_NAME);
+        stringBasedMdsAttributeValue.setValue(value);
+        return stringBasedMdsAttributeValue;
+    }
+
+    public IdpFraudEventId createIdpFraudEventAttributeValue(String fraudEventId) {
+        IdpFraudEventId idpFraudEventId = (IdpFraudEventId) openSamlBuilderFactory.getBuilder(IdpFraudEventId.TYPE_NAME).buildObject(IdpFraudEventId.DEFAULT_ELEMENT_NAME, IdpFraudEventId.TYPE_NAME);
+        idpFraudEventId.setValue(fraudEventId);
+        return idpFraudEventId;
+    }
+
+    public Gpg45Status createGpg45StatusAttributeValue(String indicator) {
+        Gpg45Status gpg45Status = (Gpg45Status) openSamlBuilderFactory.getBuilder(Gpg45Status.TYPE_NAME).buildObject(Gpg45Status.DEFAULT_ELEMENT_NAME, Gpg45Status.TYPE_NAME);
+        gpg45Status.setValue(indicator);
+        return gpg45Status;
+    }
+
+    public IPAddress createIPAddressAttributeValue(String value) {
+        IPAddress ipAddressObject = (IPAddress) openSamlBuilderFactory.getBuilder(IPAddress.TYPE_NAME).buildObject(IPAddress.DEFAULT_ELEMENT_NAME, IPAddress.TYPE_NAME);
+        ipAddressObject.setValue(value);
+        return ipAddressObject;
+    }
+
+    public StatusValue createStatusValue(String value) {
+        StatusValue statusValue = (StatusValue) openSamlBuilderFactory.getBuilder(StatusValue.DEFAULT_ELEMENT_NAME).buildObject(StatusValue.DEFAULT_ELEMENT_NAME);
+        statusValue.setValue(value);
+        return statusValue;
+    }
+
+
+    public StatusDetail createStatusDetail() {
+        StatusDetail statusDetail = (StatusDetail) openSamlBuilderFactory.getBuilder(StatusDetail.DEFAULT_ELEMENT_NAME).buildObject(StatusDetail.DEFAULT_ELEMENT_NAME);
+        return statusDetail;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/SignatureAlgorithm.java
+++ b/src/main/java/uk/gov/ida/saml/core/SignatureAlgorithm.java
@@ -1,0 +1,30 @@
+package uk.gov.ida.saml.core;
+
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+
+public enum SignatureAlgorithm {
+    DSA_SHA1 {
+        @Override
+        public String toString() {
+            return SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA1;
+        }
+    },
+    RSA_SHA1 {
+        @Override
+        public String toString() {
+            return SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1;
+        }
+    },
+    RSA_SHA256 {
+        @Override
+        public String toString() {
+            return SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256;
+        }
+    },
+    RSA_SHA512 {
+        @Override
+        public String toString() {
+            return SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA512;
+        }
+    };
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/Address.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/Address.java
@@ -1,0 +1,83 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class Address implements MdsAttributeValue, Serializable {
+    private boolean verified;
+    private DateTime from;
+    private Optional<DateTime> to = Optional.absent();
+    private Optional<String> postCode = Optional.absent();
+    private List<String> lines;
+    private Optional<String> internationalPostCode = Optional.absent();
+    private Optional<String> uprn = Optional.absent();
+
+    public Address(
+            List<String> lines,
+            String postCode,
+            String internationalPostCode,
+            String uprn,
+            DateTime from,
+            DateTime to,
+            boolean verified) {
+
+        this.internationalPostCode = Optional.fromNullable(internationalPostCode);
+        this.uprn = Optional.fromNullable(uprn);
+        this.from = from;
+        this.postCode = Optional.fromNullable(postCode);
+        this.lines = lines;
+        this.to = Optional.fromNullable(to);
+        this.verified = verified;
+    }
+
+    @JsonCreator
+    public Address(
+            @JsonProperty("lines") List<String> lines,
+            @JsonProperty("postCode") Optional<String> postCode,
+            @JsonProperty("internationalPostCode") Optional<String> internationalPostCode,
+            @JsonProperty("uprn") Optional<String> uprn,
+            @JsonProperty("from") DateTime from,
+            @JsonProperty("to") Optional<DateTime> to,
+            @JsonProperty("verified") boolean verified) {
+        this.lines = lines;
+        this.postCode = postCode;
+        this.internationalPostCode = internationalPostCode;
+        this.uprn = uprn;
+        this.from = from;
+        this.to = to;
+        this.verified = verified;
+    }
+
+    public List<String> getLines() {
+        return lines;
+    }
+
+    public Optional<String> getPostCode() {
+        return postCode;
+    }
+
+    public Optional<String> getInternationalPostCode() {
+        return internationalPostCode;
+    }
+
+    public Optional<String> getUPRN() {
+        return uprn;
+    }
+
+    public DateTime getFrom() {
+        return from;
+    }
+
+    public Optional<DateTime> getTo() {
+        return to;
+    }
+
+    public boolean isVerified() {
+        return verified;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/AddressFactory.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/AddressFactory.java
@@ -1,0 +1,52 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Attribute;
+import uk.gov.ida.saml.core.extensions.Line;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AddressFactory {
+    public Address create(List<String> lines, String postCode, String internationalPostCode, String uprn, DateTime from, DateTime to, boolean isVerified) {
+        return new Address(lines, postCode, internationalPostCode, uprn, from, to, isVerified);
+    }
+
+    public List<Address> create(Attribute attribute) {
+        List<Address> addresses = new ArrayList<>();
+        for (XMLObject xmlObject : attribute.getAttributeValues()) {
+            uk.gov.ida.saml.core.extensions.Address address = (uk.gov.ida.saml.core.extensions.Address) xmlObject;
+            addresses.add(create(address));
+        }
+        return addresses;
+    }
+
+    public Address create(uk.gov.ida.saml.core.extensions.Address addressAttributeValue) {
+        List<String> lines = new ArrayList<>();
+        for (Line originalLine : addressAttributeValue.getLines()) {
+            lines.add(originalLine.getValue());
+        }
+
+        DateTime toDate = addressAttributeValue.getTo();
+
+        DateTime fromDate = addressAttributeValue.getFrom();
+
+        String postCodeString = null;
+        if (addressAttributeValue.getPostCode() != null) {
+            postCodeString = addressAttributeValue.getPostCode().getValue();
+        }
+
+        String internationalPostCodeString = null;
+        if (addressAttributeValue.getInternationalPostCode() != null) {
+            internationalPostCodeString = addressAttributeValue.getInternationalPostCode().getValue();
+        }
+
+        String uprnString = null;
+        if (addressAttributeValue.getUPRN() != null) {
+            uprnString = addressAttributeValue.getUPRN().getValue();
+        }
+
+        return new Address(lines, postCodeString, internationalPostCodeString, uprnString, fromDate, toDate, addressAttributeValue.getVerified());
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/AssertionRestrictions.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/AssertionRestrictions.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+
+public class AssertionRestrictions {
+    private String recipient;
+    private DateTime notOnOrAfter;
+    private String inResponseTo;
+
+    protected AssertionRestrictions() {}
+
+    public AssertionRestrictions(DateTime notOnOrAfter, String inResponseTo, String recipient) {
+        this.notOnOrAfter = notOnOrAfter;
+        this.inResponseTo = inResponseTo;
+        this.recipient = recipient;
+    }
+
+    public DateTime getNotOnOrAfter() {
+        return notOnOrAfter;
+    }
+
+    public String getInResponseTo() {
+        return inResponseTo;
+    }
+
+    public String getRecipient() {
+        return this.recipient;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/AuthnContext.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/AuthnContext.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.saml.core.domain;
+
+import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
+
+public enum AuthnContext {
+    LEVEL_X(IdaAuthnContext.LEVEL_X_AUTHN_CTX),
+    LEVEL_1(IdaAuthnContext.LEVEL_1_AUTHN_CTX),
+    LEVEL_2(IdaAuthnContext.LEVEL_2_AUTHN_CTX),
+    LEVEL_3(IdaAuthnContext.LEVEL_3_AUTHN_CTX),
+    LEVEL_4(IdaAuthnContext.LEVEL_4_AUTHN_CTX);
+
+    private String uri;
+
+    AuthnContext(String uri) {
+        this.uri = uri;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/Cycle3Dataset.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/Cycle3Dataset.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.saml.core.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Cycle3Dataset {
+    private Map<String, String> attributes;
+
+    protected Cycle3Dataset(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public static Cycle3Dataset createFromData(String attributeKey, String userInputData) {
+        HashMap<String, String> attributes = new HashMap<>();
+        attributes.put(attributeKey, userInputData);
+        return new Cycle3Dataset(attributes);
+    }
+
+    public static Cycle3Dataset createFromData(Map<String, String> map) {
+        return new Cycle3Dataset(map);
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/DetailedStatusCode.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/DetailedStatusCode.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.opensaml.saml.saml2.core.StatusCode;
+
+import java.util.Optional;
+
+public enum DetailedStatusCode {
+    Success(StatusCode.SUCCESS),
+    MatchingServiceMatch(StatusCode.SUCCESS, SamlStatusCode.MATCH),
+    NoAuthenticationContext(StatusCode.RESPONDER, StatusCode.NO_AUTHN_CONTEXT),
+    SuccessNoAuthenticationContext(StatusCode.SUCCESS, StatusCode.NO_AUTHN_CONTEXT),
+    NoMatchingServiceMatchFromHub(StatusCode.SUCCESS, SamlStatusCode.NO_MATCH),
+    SamlProfileNoMatchingServiceMatchFromHub(StatusCode.RESPONDER, SamlStatusCode.NO_MATCH),
+    SimpleProfileNoMatchingServiceMatchFromHub(StatusCode.RESPONDER, SamlStatusCode.NO_MATCH),
+    NoMatchingServiceMatchFromMatchingService(StatusCode.RESPONDER, SamlStatusCode.NO_MATCH),
+    AuthenticationFailed(StatusCode.RESPONDER, StatusCode.AUTHN_FAILED),
+    RequesterErrorFromIdp(StatusCode.REQUESTER),
+    RequesterErrorRequestDeniedFromIdp(StatusCode.REQUESTER,StatusCode.REQUEST_DENIED),
+    RequesterErrorFromIdpAsSentByHub(StatusCode.RESPONDER, StatusCode.REQUESTER),
+    Healthy(StatusCode.SUCCESS, SamlStatusCode.HEALTHY),
+    UnknownUserCreateFailure(StatusCode.RESPONDER, SamlStatusCode.CREATE_FAILURE),
+    UnknownUserNoAttributeFailure(StatusCode.RESPONDER),
+    UnknownUserCreateSuccess(StatusCode.SUCCESS, SamlStatusCode.CREATED);
+
+    private final String status;
+    private final Optional<String> subStatus;
+
+    DetailedStatusCode(final String status) {
+        this.status = status;
+        this.subStatus = Optional.empty();
+    }
+
+    DetailedStatusCode(final String status, final String subStatus) {
+        this.status = status;
+        this.subStatus = Optional.ofNullable(subStatus);
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Optional<String> getSubStatus() {
+        return subStatus;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/FraudAuthnDetails.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/FraudAuthnDetails.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.saml.core.domain;
+
+public class FraudAuthnDetails {
+
+    private final String eventId;
+    private final String fraudIndicator;
+
+    public FraudAuthnDetails(String eventId, String fraudIndicator) {
+        this.eventId = eventId;
+        this.fraudIndicator = fraudIndicator;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public String getFraudIndicator() {
+        return fraudIndicator;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/FraudDetectedDetails.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/FraudDetectedDetails.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.saml.core.domain;
+
+public class FraudDetectedDetails {
+    private String idpFraudEventId;
+    private String fraudIndicator;
+
+    public FraudDetectedDetails(String idpFraudEventId, String fraudIndicator) {
+        this.idpFraudEventId = idpFraudEventId;
+        this.fraudIndicator = fraudIndicator;
+    }
+
+    public String getIdpFraudEventId() {
+        return idpFraudEventId;
+    }
+
+    public String getFraudIndicator() {
+        return fraudIndicator;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/Gender.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/Gender.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.saml.core.domain;
+
+public enum Gender {
+    FEMALE("Female"),
+    MALE("Male"),
+    NOT_SPECIFIED("Not Specified");
+
+    private String value;
+
+    Gender(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Gender fromString(String string) {
+        for (Gender gender : values()) {
+            if (gender.getValue().equalsIgnoreCase(string)) {
+                return gender;
+            }
+        }
+        throw new IllegalArgumentException("Not a legal value for gender: " + string);
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/HubAssertion.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/HubAssertion.java
@@ -1,0 +1,25 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+
+public class HubAssertion extends OutboundAssertion {
+    private Optional<Cycle3Dataset> cycle3Data = Optional.absent();
+
+    public HubAssertion(
+            String id,
+            String issuerId,
+            DateTime issueInstant,
+            PersistentId persistentId,
+            AssertionRestrictions assertionRestrictions,
+            Optional<Cycle3Dataset> cycle3Data) {
+
+        super(id, issuerId, issueInstant, persistentId, assertionRestrictions);
+
+        this.cycle3Data = cycle3Data;
+    }
+
+    public Optional<Cycle3Dataset> getCycle3Data() {
+        return cycle3Data;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/IdaMessage.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/IdaMessage.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+
+public abstract class IdaMessage {
+
+    private String id;
+    private String issuer;
+    private DateTime issueInstant;
+
+    protected IdaMessage() {
+    }
+
+    public IdaMessage(String id, String issuer, DateTime issueInstant) {
+        this.id = id;
+        this.issuer = issuer;
+        this.issueInstant = issueInstant;
+    }
+
+    public String getId(){
+        return id;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public DateTime getIssueInstant() {
+        return issueInstant;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/IdaResponse.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/IdaResponse.java
@@ -1,0 +1,11 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+
+public interface IdaResponse {
+
+    String getId();
+    String getInResponseTo();
+    DateTime getIssueInstant();
+    String getIssuer();
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/IdaSamlMessage.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/IdaSamlMessage.java
@@ -1,0 +1,22 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+
+import java.net.URI;
+
+public abstract class IdaSamlMessage extends IdaMessage {
+
+    private URI destination;
+
+    protected IdaSamlMessage() {
+    }
+
+    public IdaSamlMessage(String id, String issuer, DateTime issueInstant, URI destination) {
+        super(id, issuer, issueInstant);
+        this.destination = destination;
+    }
+
+    public URI getDestination() {
+        return destination;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/IdaSamlResponse.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/IdaSamlResponse.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+
+import java.net.URI;
+
+public abstract class IdaSamlResponse extends IdaSamlMessage implements IdaResponse {
+
+    private String inResponseTo;
+
+    protected IdaSamlResponse() {
+    }
+
+    protected IdaSamlResponse(
+            String responseId,
+            DateTime issueInstant,
+            String inResponseTo,
+            String issuer,
+            URI destination) {
+
+        super(responseId, issuer, issueInstant, destination);
+
+        this.inResponseTo = inResponseTo;
+    }
+
+    public String getInResponseTo() {
+        return inResponseTo;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/IdaStatus.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/IdaStatus.java
@@ -1,0 +1,4 @@
+package uk.gov.ida.saml.core.domain;
+
+public interface IdaStatus {
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/IdentityProviderAssertion.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/IdentityProviderAssertion.java
@@ -1,0 +1,32 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+
+public class IdentityProviderAssertion extends OutboundAssertion {
+    private Optional<MatchingDataset> matchingDataset = Optional.absent();
+    private Optional<IdentityProviderAuthnStatement> authnStatement = Optional.absent();
+
+    public IdentityProviderAssertion(
+            String id,
+            String issuerId,
+            DateTime issueInstant,
+            PersistentId persistentId,
+            AssertionRestrictions assertionRestrictions,
+            Optional<MatchingDataset> matchingDataset,
+            Optional<IdentityProviderAuthnStatement> authnStatement) {
+
+        super(id, issuerId, issueInstant, persistentId, assertionRestrictions);
+
+        this.matchingDataset = matchingDataset;
+        this.authnStatement = authnStatement;
+    }
+
+    public Optional<MatchingDataset> getMatchingDataset() {
+        return matchingDataset;
+    }
+
+    public Optional<IdentityProviderAuthnStatement> getAuthnStatement(){
+        return authnStatement;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/IdentityProviderAuthnStatement.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/IdentityProviderAuthnStatement.java
@@ -1,0 +1,50 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.google.common.base.Optional;
+
+public final class IdentityProviderAuthnStatement {
+
+    private Optional<FraudAuthnDetails> fraudAuthnDetails;
+    private IpAddress userIpAddress;
+    private AuthnContext levelOfAssurance;
+
+    private IdentityProviderAuthnStatement(
+            AuthnContext levelOfAssurance,
+            Optional<FraudAuthnDetails> fraudAuthnDetails,
+            IpAddress userIpAddress) {
+
+        this.levelOfAssurance = levelOfAssurance;
+        this.fraudAuthnDetails = fraudAuthnDetails;
+        this.userIpAddress = userIpAddress;
+    }
+
+    public AuthnContext getAuthnContext() {
+        return levelOfAssurance;
+    }
+
+    public static IdentityProviderAuthnStatement createIdentityProviderAuthnStatement(
+            AuthnContext levelOfAssurance,
+            IpAddress userIpAddress) {
+
+        return new IdentityProviderAuthnStatement(levelOfAssurance, Optional.<FraudAuthnDetails>absent(), userIpAddress);
+    }
+
+    public static IdentityProviderAuthnStatement createIdentityProviderFraudAuthnStatement(
+            FraudAuthnDetails fraudAuthnDetails,
+            IpAddress userIpAddress) {
+
+        return new IdentityProviderAuthnStatement(AuthnContext.LEVEL_X, Optional.fromNullable(fraudAuthnDetails), userIpAddress);
+    }
+
+    public boolean isFraudAuthnStatement() {
+        return fraudAuthnDetails.isPresent();
+    }
+
+    public FraudAuthnDetails getFraudAuthnDetails() {
+        return fraudAuthnDetails.orNull();
+    }
+
+    public IpAddress getUserIpAddress() {
+        return userIpAddress;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/IdpIdaStatus.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/IdpIdaStatus.java
@@ -1,0 +1,91 @@
+package uk.gov.ida.saml.core.domain;
+
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static uk.gov.ida.saml.core.domain.IdpIdaStatus.Status.RequesterError;
+
+public final class IdpIdaStatus implements IdaStatus {
+
+    public enum Status {
+        Success,
+        NoAuthenticationContext,
+        RequesterError,
+        AuthenticationFailed,
+        AuthenticationCancelled,
+        AuthenticationPending;
+    }
+    public static IdpIdaStatus success() { return new IdpIdaStatus(Status.Success);}
+
+    public static IdpIdaStatus authenticationFailed() { return new IdpIdaStatus(Status.AuthenticationFailed);}
+    public static IdpIdaStatus noAuthenticationContext() { return new IdpIdaStatus(Status.NoAuthenticationContext);}
+    public static IdpIdaStatus requesterError() { return new IdpIdaStatus(RequesterError);}
+    public static IdpIdaStatus requesterError(Optional<String> errorMessage) { return new IdpIdaStatus(RequesterError, errorMessage);}
+    public static IdpIdaStatus authenticationCancelled() {
+        return new IdpIdaStatus(Status.AuthenticationCancelled);
+    }
+    public static IdpIdaStatus authenticationPending() { return new IdpIdaStatus(Status.AuthenticationPending); }
+
+    private Status status;
+    private Optional<String> message = empty();
+
+    private IdpIdaStatus() {
+    }
+
+    private IdpIdaStatus(Status status) {
+        this(status, Optional.<String>empty());
+    }
+
+    private IdpIdaStatus(Status status, Optional<String> message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public Status getStatusCode() {
+        return status;
+    }
+
+    public Optional<String> getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        IdpIdaStatus idpIdaStatus = (IdpIdaStatus) o;
+
+        if (status != idpIdaStatus.status) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = status.hashCode();
+        result = 31 * result;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "IdaStatus{" +
+            "status=" + status +
+            ", message=" + message +
+            '}';
+    }
+
+    public static class IdpIdaStatusFactory {
+        public IdpIdaStatus create(
+                final IdpIdaStatus.Status statusCode,
+                final Optional<String> message) {
+
+            if (!statusCode.equals(RequesterError)) {
+                return new IdpIdaStatus(statusCode);
+            }
+
+            return new IdpIdaStatus(statusCode, message);
+        }
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/InboundResponseFromIdp.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/InboundResponseFromIdp.java
@@ -1,0 +1,48 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+import org.opensaml.xmlsec.signature.Signature;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class InboundResponseFromIdp extends IdaSamlResponse {
+    private Optional<PassthroughAssertion> matchingDatasetAssertion;
+    private Optional<PassthroughAssertion> authnStatementAssertion;
+    private Optional<Signature> signature;
+    private IdpIdaStatus status;
+
+    public InboundResponseFromIdp(
+            String id,
+            String inResponseTo,
+            String issuer,
+            DateTime issueInstant,
+            IdpIdaStatus status,
+            Optional<Signature> signature,
+            Optional<PassthroughAssertion> matchingDatasetAssertion,
+            URI destination,
+            Optional<PassthroughAssertion> authnStatementAssertion) {
+        super(id, issueInstant, inResponseTo, issuer, destination);
+        this.signature = signature;
+        this.matchingDatasetAssertion = matchingDatasetAssertion;
+        this.authnStatementAssertion = authnStatementAssertion;
+        this.status = status;
+    }
+
+    public Optional<PassthroughAssertion> getMatchingDatasetAssertion() {
+        return matchingDatasetAssertion;
+    }
+
+    public Optional<PassthroughAssertion> getAuthnStatementAssertion() {
+        return authnStatementAssertion;
+    }
+
+    public Optional<Signature> getSignature() {
+        return signature;
+    }
+
+    public IdpIdaStatus getStatus() {
+        return status;
+    }
+
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/IpAddress.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/IpAddress.java
@@ -1,0 +1,14 @@
+package uk.gov.ida.saml.core.domain;
+
+public class IpAddress {
+
+    private final String ipAddressString;
+
+    public IpAddress(String ipAddressString) {
+        this.ipAddressString = ipAddressString;
+    }
+
+    public String getStringValue() {
+        return this.ipAddressString;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/MatchingDataset.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/MatchingDataset.java
@@ -1,0 +1,70 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.joda.time.LocalDate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MatchingDataset {
+    
+    private List<SimpleMdsValue<String>> firstNames = new ArrayList<>();
+    private List<SimpleMdsValue<String>> middleNames = new ArrayList<>();
+    private List<SimpleMdsValue<String>> surnames = new ArrayList<>();
+    private Optional<SimpleMdsValue<Gender>> gender = Optional.absent();
+    private List<SimpleMdsValue<LocalDate>> dateOfBirths = new ArrayList<>();
+    private List<Address> currentAddresses = new ArrayList<>();
+    private List<Address> previousAddresses = new ArrayList<>();
+
+    public MatchingDataset(
+            List<SimpleMdsValue<String>> firstNames,
+            List<SimpleMdsValue<String>> middleNames,
+            List<SimpleMdsValue<String>> surnames,
+            Optional<SimpleMdsValue<Gender>> gender,
+            List<SimpleMdsValue<LocalDate>> dateOfBirths,
+            List<Address> currentAddresses,
+            List<Address> previousAddresses) {
+
+        this.firstNames = firstNames;
+        this.middleNames = middleNames;
+        this.surnames = surnames;
+        this.gender = gender;
+        this.dateOfBirths = dateOfBirths;
+        this.currentAddresses = currentAddresses;
+        this.previousAddresses = previousAddresses;
+    }
+
+    public List<SimpleMdsValue<String>> getFirstNames() {
+        return firstNames;
+    }
+
+    public List<SimpleMdsValue<String>> getMiddleNames() {
+        return middleNames;
+    }
+
+    public List<SimpleMdsValue<String>> getSurnames() {
+        return surnames;
+    }
+
+    public Optional<SimpleMdsValue<Gender>> getGender() {
+        return gender;
+    }
+
+    public List<SimpleMdsValue<LocalDate>> getDateOfBirths() {
+        return dateOfBirths;
+    }
+
+    public List<Address> getCurrentAddresses() {
+        return currentAddresses;
+    }
+
+    public List<Address> getPreviousAddresses() {
+        return previousAddresses;
+    }
+
+    public List<Address> getAddresses() {
+        return ImmutableList.copyOf(Iterables.concat(currentAddresses, previousAddresses));
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/MatchingServiceIdaStatus.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/MatchingServiceIdaStatus.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.saml.core.domain;
+
+public enum MatchingServiceIdaStatus implements IdaStatus {
+    NoMatchingServiceMatchFromMatchingService,
+    RequesterError,
+    MatchingServiceMatch,
+    UserAccountCreated,
+    Healthy
+    }

--- a/src/main/java/uk/gov/ida/saml/core/domain/MdsAttributeValue.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/MdsAttributeValue.java
@@ -1,0 +1,12 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+
+public interface MdsAttributeValue {
+    DateTime getFrom();
+
+    Optional<DateTime> getTo();
+
+    boolean isVerified();
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/OutboundAssertion.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/OutboundAssertion.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+
+public class OutboundAssertion {
+
+    private String id;
+    private String issuerId;
+    private DateTime issueInstant;
+    private PersistentId persistentId;
+    private AssertionRestrictions assertionRestrictions;
+
+    public OutboundAssertion(
+            String id,
+            String issuerId,
+            DateTime issueInstant,
+            PersistentId persistentId,
+            AssertionRestrictions assertionRestrictions) {
+
+        this.id = id;
+        this.issuerId = issuerId;
+        this.issueInstant = issueInstant;
+        this.persistentId = persistentId;
+        this.assertionRestrictions = assertionRestrictions;
+    }
+
+    public PersistentId getPersistentId() {
+        return persistentId;
+    }
+
+    public AssertionRestrictions getAssertionRestrictions() {
+        return assertionRestrictions;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getIssuerId() {
+        return issuerId;
+    }
+
+    public DateTime getIssueInstant() {
+        return issueInstant;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/OutboundResponseFromHub.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/OutboundResponseFromHub.java
@@ -1,0 +1,34 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class OutboundResponseFromHub extends IdaSamlResponse {
+
+    private Optional<String> matchingServiceAssertion;
+    private TransactionIdaStatus status;
+
+    public OutboundResponseFromHub(
+            String responseId,
+            String inResponseTo,
+            String issuer,
+            DateTime issueInstant,
+            TransactionIdaStatus status,
+            Optional<String> matchingServiceAssertion,
+            URI destination) {
+
+        super(responseId, issueInstant, inResponseTo, issuer, destination);
+        this.matchingServiceAssertion = matchingServiceAssertion;
+        this.status = status;
+    }
+
+    public Optional<String> getMatchingServiceAssertion() {
+        return matchingServiceAssertion;
+    }
+
+    public TransactionIdaStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/PassthroughAssertion.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/PassthroughAssertion.java
@@ -1,0 +1,55 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.google.common.base.Optional;
+
+import java.io.Serializable;
+
+import static com.google.common.base.Optional.absent;
+
+public class PassthroughAssertion implements Serializable {
+
+    private PersistentId persistentId;
+    // this is optional because this is used for both AuthnStatement and MDS Assertions
+    private Optional<AuthnContext> authnContext = absent();
+    private String underlyingAssertionBlob;
+    private Optional<FraudDetectedDetails> fraudDetectedDetails = absent();
+    private Optional<String> principalIpAddressAsSeenByIdp;
+
+    public PassthroughAssertion(
+            PersistentId persistentId,
+            Optional<AuthnContext> levelOfAssurance,
+            String underlyingAssertionBlob,
+            Optional<FraudDetectedDetails> fraudDetectedDetails,
+            Optional<String> principalIpAddressAsSeenByIdp) {
+
+        this.persistentId = persistentId;
+        this.authnContext = levelOfAssurance;
+        this.underlyingAssertionBlob = underlyingAssertionBlob;
+        this.fraudDetectedDetails = fraudDetectedDetails;
+        this.principalIpAddressAsSeenByIdp = principalIpAddressAsSeenByIdp;
+    }
+
+    public String getUnderlyingAssertionBlob() {
+        return underlyingAssertionBlob;
+    }
+
+    public Optional<AuthnContext> getAuthnContext() {
+        return authnContext;
+    }
+
+    public PersistentId getPersistentId() {
+        return persistentId;
+    }
+
+    public boolean isFraudulent() {
+        return authnContext.isPresent() && authnContext.get().equals(AuthnContext.LEVEL_X);
+    }
+
+    public Optional<FraudDetectedDetails> getFraudDetectedDetails() {
+        return fraudDetectedDetails;
+    }
+
+    public Optional<String> getPrincipalIpAddressAsSeenByIdp() {
+        return principalIpAddressAsSeenByIdp;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/PersistentId.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/PersistentId.java
@@ -1,0 +1,16 @@
+package uk.gov.ida.saml.core.domain;
+
+import java.io.Serializable;
+
+public class PersistentId implements Serializable {
+
+    private String nameId;
+
+    public PersistentId(String nameId) {
+        this.nameId = nameId;
+    }
+
+    public String getNameId() {
+        return nameId;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/SimpleMdsValue.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/SimpleMdsValue.java
@@ -1,0 +1,39 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.DateTime;
+
+import java.io.Serializable;
+
+public class SimpleMdsValue<T> implements Serializable {
+
+    private T value;
+    private DateTime from;
+    private DateTime to;
+    private boolean verified;
+
+    @JsonCreator
+    public SimpleMdsValue(@JsonProperty("value") T value, @JsonProperty("from") DateTime from, @JsonProperty("to") DateTime to, @JsonProperty("verified") boolean verified) {
+        this.value = value;
+        this.from = from;
+        this.to = to;
+        this.verified = verified;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public DateTime getFrom() {
+        return from;
+    }
+
+    public DateTime getTo() {
+        return to;
+    }
+
+    public boolean isVerified() {
+        return verified;
+    }
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/TransactionIdaStatus.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/TransactionIdaStatus.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.saml.core.domain;
+
+public enum TransactionIdaStatus implements IdaStatus {
+    Success,
+    RequesterError,
+    NoAuthenticationContext,
+    NoMatchingServiceMatchFromHub,
+    AuthenticationFailed
+}

--- a/src/main/java/uk/gov/ida/saml/core/domain/UnknownUserCreationIdaStatus.java
+++ b/src/main/java/uk/gov/ida/saml/core/domain/UnknownUserCreationIdaStatus.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.saml.core.domain;
+
+public enum UnknownUserCreationIdaStatus implements IdaStatus {
+    Success,
+    CreateFailure,
+    NoAttributeFailure,
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/AddressBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/AddressBuilder.java
@@ -1,0 +1,69 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.Address;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AddressBuilder {
+
+    private List<String> lines = new ArrayList<>();
+    private Optional<String> postCode = Optional.absent();
+    private Optional<String> internationalPostCode = Optional.absent();
+    private Optional<String> uprn = Optional.absent();
+    private DateTime fromDate = DateTime.parse("2001-01-01");
+    private Optional<DateTime> toDate = Optional.absent();
+    private boolean verified = false;
+
+    public static AddressBuilder anAddress() {
+        return new AddressBuilder();
+    }
+
+    public Address build() {
+        return new Address(
+                lines,
+                postCode,
+                internationalPostCode,
+                uprn,
+                fromDate,
+                toDate,
+                verified);
+    }
+
+    public AddressBuilder withLines(final List<String> lines) {
+        this.lines = lines;
+        return this;
+    }
+
+    public AddressBuilder withPostCode(final String postCode) {
+        this.postCode = Optional.fromNullable(postCode);
+        return this;
+    }
+
+    public AddressBuilder withInternationalPostCode(final String internationalPostCode) {
+        this.internationalPostCode = Optional.fromNullable(internationalPostCode);
+        return this;
+    }
+
+    public AddressBuilder withUPRN(final String uprn) {
+        this.uprn = Optional.fromNullable(uprn);
+        return this;
+    }
+
+    public AddressBuilder withFromDate(final DateTime fromDate) {
+        this.fromDate = fromDate;
+        return this;
+    }
+
+    public AddressBuilder withToDate(final DateTime toDate) {
+        this.toDate = Optional.fromNullable(toDate);
+        return this;
+    }
+
+    public AddressBuilder withVerified(boolean verified) {
+        this.verified = verified;
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/AssertionRestrictionsBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/AssertionRestrictionsBuilder.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AssertionRestrictions;
+
+public class AssertionRestrictionsBuilder {
+
+    private DateTime notOnOrAfter = DateTime.now().plusDays(2);
+    private String inResponseTo = "default-in-response-to";
+    private String recipient = "recipient";
+
+    public static AssertionRestrictionsBuilder anAssertionRestrictions() {
+        return new AssertionRestrictionsBuilder();
+    }
+
+    public AssertionRestrictions build() {
+        return new AssertionRestrictions(
+                notOnOrAfter,
+                inResponseTo,
+                recipient);
+    }
+
+    public AssertionRestrictionsBuilder withNotOnOrAfter(DateTime notOnOrAfter) {
+        this.notOnOrAfter = notOnOrAfter;
+        return this;
+    }
+
+    public AssertionRestrictionsBuilder withInResponseTo(String inResponseTo) {
+        this.inResponseTo = inResponseTo;
+        return this;
+    }
+
+    public AssertionRestrictionsBuilder withRecipient(String recipient) {
+        this.recipient = recipient;
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/Cycle3DatasetBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/Cycle3DatasetBuilder.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import uk.gov.ida.saml.core.domain.Cycle3Dataset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Cycle3DatasetBuilder {
+
+    private Map<String,String> attributes = new HashMap<>();
+
+    public static Cycle3DatasetBuilder aCycle3Dataset() {
+        return new Cycle3DatasetBuilder();
+    }
+
+    public Cycle3Dataset build() {
+        return Cycle3Dataset.createFromData(attributes);
+    }
+
+    public Cycle3DatasetBuilder addCycle3Data(String name, String value) {
+        attributes.put(name, value);
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/HubAssertionBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/HubAssertionBuilder.java
@@ -1,0 +1,67 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AssertionRestrictions;
+import uk.gov.ida.saml.core.domain.Cycle3Dataset;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+import java.util.UUID;
+
+import static com.google.common.base.Optional.absent;
+import static uk.gov.ida.saml.core.test.builders.PersistentIdBuilder.aPersistentId;
+
+public class HubAssertionBuilder {
+
+    private String id = "assertion-id" + UUID.randomUUID();
+    private String issuerId = "assertion issuer id";
+    private DateTime issueInstant = DateTime.now();
+    private PersistentId persistentId = aPersistentId().build();
+    private AssertionRestrictions assertionRestrictions = AssertionRestrictionsBuilder.anAssertionRestrictions().build();
+    private Optional<Cycle3Dataset> cycle3Data = absent();
+
+    public static HubAssertionBuilder aHubAssertion() {
+        return new HubAssertionBuilder();
+    }
+
+    public HubAssertion build() {
+        return new HubAssertion(
+                id,
+                issuerId,
+                issueInstant,
+                persistentId,
+                assertionRestrictions,
+                cycle3Data);
+    }
+
+    public HubAssertionBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public HubAssertionBuilder withIssuerId(String issuerId) {
+        this.issuerId = issuerId;
+        return this;
+    }
+
+    public HubAssertionBuilder withIssueInstant(DateTime issueInstant) {
+        this.issueInstant = issueInstant;
+        return this;
+    }
+
+    public HubAssertionBuilder withPersistentId(PersistentId persistentId) {
+        this.persistentId = persistentId;
+        return this;
+    }
+
+    public HubAssertionBuilder withAssertionRestrictions(AssertionRestrictions assertionRestrictions) {
+        this.assertionRestrictions = assertionRestrictions;
+        return this;
+    }
+
+    public HubAssertionBuilder withCycle3Data(Cycle3Dataset cycle3Data) {
+        this.cycle3Data = Optional.fromNullable(cycle3Data);
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/IdentityProviderAuthnStatementBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/IdentityProviderAuthnStatementBuilder.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.FraudAuthnDetails;
+import uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement;
+import uk.gov.ida.saml.core.domain.IpAddress;
+
+import static com.google.common.base.Optional.fromNullable;
+import static uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement.createIdentityProviderAuthnStatement;
+import static uk.gov.ida.saml.core.domain.IdentityProviderAuthnStatement.createIdentityProviderFraudAuthnStatement;
+
+public class IdentityProviderAuthnStatementBuilder {
+
+    private Optional<FraudAuthnDetails> fraudAuthnDetails = Optional.absent();
+    private AuthnContext authnContext = AuthnContext.LEVEL_1;
+    private Optional<IpAddress> userIpAddress = fromNullable(IpAddressBuilder.anIpAddress().build());
+
+    public static IdentityProviderAuthnStatementBuilder anIdentityProviderAuthnStatement() {
+        return new IdentityProviderAuthnStatementBuilder();
+    }
+
+    public IdentityProviderAuthnStatement build() {
+        if (fraudAuthnDetails.isPresent()) {
+            return createIdentityProviderFraudAuthnStatement(fraudAuthnDetails.get(), userIpAddress.orNull());
+        }
+        return createIdentityProviderAuthnStatement(authnContext, userIpAddress.orNull());
+    }
+
+    public IdentityProviderAuthnStatementBuilder withAuthnContext(AuthnContext authnContext) {
+        this.authnContext = authnContext;
+        return this;
+    }
+
+    public IdentityProviderAuthnStatementBuilder withFraudDetails(FraudAuthnDetails fraudDetails) {
+        this.fraudAuthnDetails = Optional.fromNullable(fraudDetails);
+        return this;
+    }
+
+    public IdentityProviderAuthnStatementBuilder withUserIpAddress(IpAddress userIpAddress) {
+        this.userIpAddress = fromNullable(userIpAddress);
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/IpAddressBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/IpAddressBuilder.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import uk.gov.ida.saml.core.domain.IpAddress;
+
+public class IpAddressBuilder {
+
+    private String ipAddress = "1.2.3.4";
+
+    public static IpAddressBuilder anIpAddress() {
+        return new IpAddressBuilder();
+    }
+
+    public IpAddress build() {
+        return new IpAddress(ipAddress);
+    }
+
+    public IpAddressBuilder withValue(String value) {
+        this.ipAddress = value;
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/MatchingDatasetBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/MatchingDatasetBuilder.java
@@ -1,0 +1,113 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import uk.gov.ida.saml.core.domain.Address;
+import uk.gov.ida.saml.core.domain.AddressFactory;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Optional.absent;
+import static com.google.common.base.Optional.fromNullable;
+import static java.util.Arrays.asList;
+
+public class MatchingDatasetBuilder {
+
+    private List<SimpleMdsValue<String>> firstnames = new ArrayList<>();
+    private List<SimpleMdsValue<String>> middleNames = new ArrayList<>();
+    private List<SimpleMdsValue<String>> surnames = new ArrayList<>();
+    private Optional<SimpleMdsValue<Gender>> gender = absent();
+    private List<SimpleMdsValue<LocalDate>> dateOfBirths = new ArrayList<>();
+    private List<Address> currentAddresses = new ArrayList<>();
+    private List<Address> previousAddresses = new ArrayList<>();
+
+    public static MatchingDatasetBuilder aMatchingDataset() {
+        return new MatchingDatasetBuilder();
+    }
+
+    public static MatchingDatasetBuilder aFullyPopulatedMatchingDataset() {
+        final List<Address> currentAddressList = asList(new AddressFactory().create(asList("subject-address-line-1"), "subject-address-post-code", "internation-postcode", "uprn", DateTime.parse("1999-03-15"), DateTime.parse("2000-02-09"), true));
+        final List<Address> previousAddressList = asList(new AddressFactory().create(asList("previous-address-line-1"), "subject-address-post-code", "internation-postcode", "uprn", DateTime.parse("1999-03-15"), DateTime.parse("2000-02-09"), true));
+        final SimpleMdsValue<String> currentSurname = SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("subject-currentSurname").withVerifiedStatus(true).build();
+        return aMatchingDataset()
+                .addFirstname(SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("subject-firstname").withVerifiedStatus(true).build())
+                .addMiddleNames(SimpleMdsValueBuilder.<String>aSimpleMdsValue().withValue("subject-middlename").withVerifiedStatus(true).build())
+                .withSurnameHistory(asList(currentSurname))
+                .withGender(SimpleMdsValueBuilder.<Gender>aSimpleMdsValue().withValue(Gender.FEMALE).withVerifiedStatus(true).build())
+                .addDateOfBirth(SimpleMdsValueBuilder.<LocalDate>aSimpleMdsValue().withValue(LocalDate.parse("2000-02-09")).withVerifiedStatus(true).build())
+                .withCurrentAddresses(currentAddressList)
+                .withPreviousAddresses(previousAddressList);
+    }
+
+    public MatchingDataset build() {
+        return new MatchingDataset(firstnames, middleNames, surnames, gender, dateOfBirths, currentAddresses, previousAddresses);
+    }
+
+    public MatchingDatasetBuilder addFirstname(SimpleMdsValue<String> firstname) {
+        this.firstnames.add(firstname);
+        return this;
+    }
+
+    public MatchingDatasetBuilder addMiddleNames(SimpleMdsValue<String> middleNames) {
+        this.middleNames.add(middleNames);
+        return this;
+    }
+
+    public MatchingDatasetBuilder addSurname(SimpleMdsValue<String> surname) {
+        this.surnames.add(surname);
+        return this;
+    }
+
+    public MatchingDatasetBuilder withGender(SimpleMdsValue<Gender> gender) {
+        this.gender = fromNullable(gender);
+        return this;
+    }
+
+    public MatchingDatasetBuilder addDateOfBirth(SimpleMdsValue<LocalDate> dateOfBirth) {
+        this.dateOfBirths.add(dateOfBirth);
+        return this;
+    }
+
+    public MatchingDatasetBuilder withCurrentAddresses(List<Address> currentAddresses) {
+        this.currentAddresses = currentAddresses;
+        return this;
+    }
+
+    public MatchingDatasetBuilder withPreviousAddresses(List<Address> previousAddresses) {
+        this.previousAddresses = previousAddresses;
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutFirstName() {
+        this.firstnames.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutMiddleName() {
+        this.middleNames.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutSurname() {
+        this.surnames.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withoutDateOfBirth() {
+        this.dateOfBirths.clear();
+        return this;
+    }
+
+    public MatchingDatasetBuilder withSurnameHistory(
+            final List<SimpleMdsValue<String>> surnameHistory) {
+
+        this.surnames.clear();
+        this.surnames.addAll(surnameHistory);
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/PersistentIdBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/PersistentIdBuilder.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+public class PersistentIdBuilder {
+
+    private String nameId = "default-name-id";
+
+    public static PersistentIdBuilder aPersistentId() {
+        return new PersistentIdBuilder();
+    }
+
+    public PersistentId build() {
+        return new PersistentId(nameId);
+    }
+
+    public PersistentIdBuilder withNameId(String persistentId) {
+        this.nameId = persistentId;
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
@@ -1,0 +1,125 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.joda.time.DateTime;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.domain.IdpIdaStatus;
+import uk.gov.ida.saml.core.domain.InboundResponseFromIdp;
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+
+public class ResponseForHubBuilder {
+
+    private String responseId = "response-id";
+    private String inResponseTo = "request-id";
+    private String issuerId = "issuer-id";
+    private DateTime issueInstant = DateTime.now();
+    private TransactionIdaStatus transactionIdpStatus = TransactionIdaStatus.Success;
+    private IdpIdaStatus idpIdaStatus = IdpIdaStatus.success();
+    private Optional<Signature> signature = null;
+    private Optional<PassthroughAssertion> authnStatementAssertion = empty();
+    private Optional<PassthroughAssertion> matchingDatasetAssertion = empty();
+    private Optional<String> matchingServiceAssertion = empty();
+
+
+    public static ResponseForHubBuilder anAuthnResponse() {
+        return new ResponseForHubBuilder();
+    }
+
+    public InboundResponseFromIdp buildInboundFromIdp() {
+        return new InboundResponseFromIdp(
+                responseId,
+                inResponseTo,
+                issuerId,
+                issueInstant,
+                idpIdaStatus,
+                signature,
+                matchingDatasetAssertion,
+                null,
+                authnStatementAssertion
+        );
+    }
+
+    public InboundResponseFromIdp buildSuccessFromIdp() {
+        return new InboundResponseFromIdp(
+                responseId,
+                inResponseTo,
+                issuerId,
+                issueInstant,
+                idpIdaStatus,
+                signature,
+                matchingDatasetAssertion,
+                null,
+                authnStatementAssertion
+        );
+    }
+
+    public OutboundResponseFromHub buildOutboundResponseFromHub() {
+        return new OutboundResponseFromHub(
+                responseId,
+                inResponseTo,
+                TestEntityIds.HUB_ENTITY_ID,
+                issueInstant,
+                transactionIdpStatus,
+                matchingServiceAssertion,
+                URI.create("blah"));
+    }
+
+
+    public ResponseForHubBuilder withResponseId(String responseId) {
+        this.responseId = responseId;
+        return this;
+    }
+
+    public ResponseForHubBuilder withInResponseTo(String inResponseTo) {
+        this.inResponseTo = inResponseTo;
+        return this;
+    }
+
+    public ResponseForHubBuilder withIssuerId(String issuerId) {
+        this.issuerId = issuerId;
+        return this;
+    }
+
+    public ResponseForHubBuilder withIssueInstant(DateTime issueInstant) {
+        this.issueInstant = issueInstant;
+        return this;
+    }
+
+    public ResponseForHubBuilder withIdpIdaStatus(IdpIdaStatus status) {
+        this.idpIdaStatus = status;
+        return this;
+    }
+
+    public ResponseForHubBuilder withTransactionIdaStatus(TransactionIdaStatus status) {
+        this.transactionIdpStatus = status;
+        return this;
+    }
+
+    public ResponseForHubBuilder withSignature(Signature signature) {
+        this.signature = ofNullable(signature);
+        return this;
+    }
+
+    public ResponseForHubBuilder withAuthnStatementAssertion(PassthroughAssertion authnStatementAssertion) {
+        this.authnStatementAssertion = ofNullable(authnStatementAssertion);
+        return this;
+    }
+
+    public ResponseForHubBuilder withMatchingDatasetAssertion(PassthroughAssertion matchingDatasetAssertion) {
+        this.matchingDatasetAssertion = ofNullable(matchingDatasetAssertion);
+        return this;
+    }
+
+    public ResponseForHubBuilder withMatchingServiceAssertion(String matchingServiceAssertion) {
+        this.matchingServiceAssertion = ofNullable(matchingServiceAssertion);
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/core/test/builders/SimpleMdsValueBuilder.java
+++ b/src/test/java/uk/gov/ida/saml/core/test/builders/SimpleMdsValueBuilder.java
@@ -1,0 +1,41 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+
+public class SimpleMdsValueBuilder<T> {
+
+    private T value = null;
+
+    private DateTime from = DateTime.now().minusDays(5);
+    private DateTime to = DateTime.now().plusDays(5);
+    private boolean verified = false;
+
+    public static <T> SimpleMdsValueBuilder<T> aSimpleMdsValue() {
+        return new SimpleMdsValueBuilder<>();
+    }
+
+    public SimpleMdsValue<T> build() {
+        return new SimpleMdsValue<>(value, from, to, verified);
+    }
+
+    public SimpleMdsValueBuilder<T> withValue(T value) {
+        this.value = value;
+        return this;
+    }
+
+    public SimpleMdsValueBuilder<T> withFrom(DateTime from) {
+        this.from = from;
+        return this;
+    }
+
+    public SimpleMdsValueBuilder<T> withTo(DateTime to) {
+        this.to = to;
+        return this;
+    }
+
+    public SimpleMdsValueBuilder<T> withVerifiedStatus(boolean verified) {
+        this.verified = verified;
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/ida/saml/hub/factories/AttributeFactory_1_1Test.java
+++ b/src/test/java/uk/gov/ida/saml/hub/factories/AttributeFactory_1_1Test.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.Attribute;
-import uk.gov.ida.saml.hub.factories.AttributeFactory_1_1;
 import uk.gov.ida.saml.core.domain.Gender;
 import uk.gov.ida.saml.core.domain.SimpleMdsValue;
 


### PR DESCRIPTION
Since the library has been emptied - we've removed the dependency on
saml-domain-objects and inlined the required objects

Pair: @felixmarcusmillne @minhngocd